### PR TITLE
Fixed bug in Balance.cpp

### DIFF
--- a/rawTX/Balance.cpp
+++ b/rawTX/Balance.cpp
@@ -5,7 +5,7 @@
 
 using namespace bc;
 
-uint64_t balancer(const chain::history::list& rows)
+uint64_t balancer(const auto& rows)
 {
 		uint64_t unspent_balance = 0;
 
@@ -29,7 +29,7 @@ void getBalance(wallet::payment_address address)
 	client::obelisk_client client(connection);
 
 
-	static const auto on_done = [](const chain::history::list& rows)
+	static const auto on_done = [](const auto& rows)
 	{
 		uint64_t balance = balancer(rows);
 		std::cout<< encode_base10(balance, 8) << std::endl;


### PR DESCRIPTION
Fixed the " 'history' in namespace 'libbitcoin::chain' does not name a type " bug.
Though, now, compilation must be done with the `-std=c++14` flag